### PR TITLE
Implemented CRUD for All Entities

### DIFF
--- a/src/main/java/com/habitude/HabitudeApplication.java
+++ b/src/main/java/com/habitude/HabitudeApplication.java
@@ -2,10 +2,20 @@ package com.habitude;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(
+        // Exclude Spring Security’s auto-configuration
+        // → This disables all of Spring Boot’s default security setup
+        //    so no login page, no authentication/authorization checks.
+        // → Useful for rapid prototyping or when we want completely open
+        //    endpoints while we build out our controllers.
+        exclude = { SecurityAutoConfiguration.class }
+)
 public class HabitudeApplication {
+
     public static void main(String[] args) {
+        // Bootstraps the entire Spring context and starts the embedded server
         SpringApplication.run(HabitudeApplication.class, args);
     }
 }

--- a/src/main/java/com/habitude/controllers/GoalController.java
+++ b/src/main/java/com/habitude/controllers/GoalController.java
@@ -1,0 +1,68 @@
+package com.habitude.controllers;
+
+import com.habitude.model.Goal;
+import com.habitude.model.Subject;
+import com.habitude.repository.GoalRepository;
+import com.habitude.repository.SubjectRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+public class GoalController {
+
+    private final GoalRepository goalRepo;
+    private final SubjectRepository subjectRepo;
+
+    public GoalController(GoalRepository goalRepo,
+                          SubjectRepository subjectRepo) {
+        this.goalRepo    = goalRepo;
+        this.subjectRepo = subjectRepo;
+    }
+
+    // 1) Create a new goal for a subject
+    @PostMapping("/subjects/{subjectId}/goals")
+    @ResponseStatus(HttpStatus.CREATED)
+    public Goal createGoal(@PathVariable Long subjectId,
+                           @RequestBody Goal input) {
+        Subject subject = subjectRepo.findById(subjectId)
+                .orElseThrow(() -> new RuntimeException("Subject not found"));
+        input.setSubject(subject);
+        return goalRepo.save(input);
+    }
+
+    // 2) List all goals for a subject
+    @GetMapping("/subjects/{subjectId}/goals")
+    public List<Goal> getGoalsForSubject(@PathVariable Long subjectId) {
+        return goalRepo.findBySubjectId(subjectId);
+    }
+
+    // 3) Get a single goal by its ID
+    @GetMapping("/goals/{id}")
+    public Goal getGoal(@PathVariable Long id) {
+        return goalRepo.findById(id)
+                .orElseThrow(() -> new RuntimeException("Goal not found"));
+    }
+
+    // 4) Update a goal
+    @PutMapping("/goals/{id}")
+    public Goal updateGoal(@PathVariable Long id,
+                           @RequestBody Goal updated) {
+        Goal existing = goalRepo.findById(id)
+                .orElseThrow(() -> new RuntimeException("Goal not found"));
+        existing.setDescription(updated.getDescription());
+        existing.setTargetDate(updated.getTargetDate());
+        existing.setStatus(updated.getStatus());
+        return goalRepo.save(existing);
+    }
+
+    // 5) Delete a goal
+    @DeleteMapping("/goals/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteGoal(@PathVariable Long id) {
+        goalRepo.deleteById(id);
+    }
+}
+

--- a/src/main/java/com/habitude/controllers/LLMFeedbackController.java
+++ b/src/main/java/com/habitude/controllers/LLMFeedbackController.java
@@ -1,0 +1,79 @@
+package com.habitude.controllers;
+
+import com.habitude.model.LLMFeedback;
+import com.habitude.model.Observation;
+import com.habitude.repository.LLMFeedbackRepository;
+import com.habitude.repository.ObservationRepository;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.http.HttpStatus;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+public class LLMFeedbackController {
+
+    private final LLMFeedbackRepository fbRepo;
+    private final ObservationRepository obsRepo;
+
+    public LLMFeedbackController(
+            LLMFeedbackRepository fbRepo,
+            ObservationRepository obsRepo
+    ) {
+        this.fbRepo = fbRepo;
+        this.obsRepo = obsRepo;
+    }
+
+    /** 1) Create a new feedback for an existing observation */
+    @PostMapping("/observations/{obsId}/llm-feedback")
+    @ResponseStatus(HttpStatus.CREATED)
+    public LLMFeedback createFeedback(
+            @PathVariable Long obsId,
+            @RequestBody LLMFeedback input
+    ) {
+        Observation obs = obsRepo.findById(obsId)
+                .orElseThrow(() -> new RuntimeException("Observation not found"));
+        input.setObservation(obs);
+        return fbRepo.save(input);
+    }
+
+    /** 2) List all feedback for a given observation */
+    @GetMapping("/observations/{obsId}/llm-feedback")
+    public List<LLMFeedback> listForObservation(@PathVariable Long obsId) {
+        return fbRepo.findByObservationId(obsId);
+    }
+
+    /** 3) GET all feedback entries */
+    @GetMapping("/llm-feedback")
+    public List<LLMFeedback> allFeedback() {
+        return fbRepo.findAll();
+    }
+
+    /** 4) GET one by its ID */
+    @GetMapping("/llm-feedback/{id}")
+    public LLMFeedback getOne(@PathVariable Long id) {
+        return fbRepo.findById(id)
+                .orElseThrow(() -> new RuntimeException("Feedback not found"));
+    }
+
+    /** 5) Update an existing feedback entry */
+    @PutMapping("/llm-feedback/{id}")
+    public LLMFeedback update(
+            @PathVariable Long id,
+            @RequestBody LLMFeedback updated
+    ) {
+        LLMFeedback existing = fbRepo.findById(id)
+                .orElseThrow(() -> new RuntimeException("Feedback not found"));
+        existing.setSuggestion(updated.getSuggestion());
+        existing.setAccepted(updated.getAccepted());
+        existing.setConfidenceScore(updated.getConfidenceScore());
+        // (we typically don’t change observation or generatedAt)
+        return fbRepo.save(existing);
+    }
+
+    /** 6) Delete a feedback entry */
+    @DeleteMapping("/llm-feedback/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
+        fbRepo.deleteById(id);
+    }
+}

--- a/src/main/java/com/habitude/controllers/SubjectController.java
+++ b/src/main/java/com/habitude/controllers/SubjectController.java
@@ -1,0 +1,65 @@
+package com.habitude.controllers;
+
+import com.habitude.model.Subject;
+import com.habitude.model.User;
+import com.habitude.repository.SubjectRepository;
+import com.habitude.repository.UserRepository;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.http.HttpStatus;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+public class SubjectController {
+
+    private final SubjectRepository subjectRepo;
+    private final UserRepository   userRepo;
+
+    public SubjectController(SubjectRepository subjectRepo,
+                             UserRepository userRepo) {
+        this.subjectRepo = subjectRepo;
+        this.userRepo    = userRepo;
+    }
+
+    // 1) Create a new subject for a user
+    @PostMapping("/users/{userId}/subjects")
+    @ResponseStatus(HttpStatus.CREATED)
+    public Subject createSubject(@PathVariable Long userId,
+                                 @RequestBody Subject input) {
+        User owner = userRepo.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        input.setUser(owner);
+        return subjectRepo.save(input);
+    }
+
+    // 2) List all subjects for a user
+    @GetMapping("/users/{userId}/subjects")
+    public List<Subject> getSubjectsForUser(@PathVariable Long userId) {
+        return subjectRepo.findByUserId(userId);
+    }
+
+    // 3) Get a single subject by its ID
+    @GetMapping("/subjects/{id}")
+    public Subject getSubject(@PathVariable Long id) {
+        return subjectRepo.findById(id)
+                .orElseThrow(() -> new RuntimeException("Subject not found"));
+    }
+
+    // 4) Update a subject
+    @PutMapping("/subjects/{id}")
+    public Subject updateSubject(@PathVariable Long id,
+                                 @RequestBody Subject updated) {
+        Subject existing = subjectRepo.findById(id)
+                .orElseThrow(() -> new RuntimeException("Subject not found"));
+        existing.setName(updated.getName());
+        existing.setDob(updated.getDob());
+        existing.setNotes(updated.getNotes());
+        return subjectRepo.save(existing);
+    }
+
+    // 5) Delete a subject
+    @DeleteMapping("/subjects/{id}")
+    public void deleteSubject(@PathVariable Long id) {
+        subjectRepo.deleteById(id);
+    }
+}

--- a/src/main/java/com/habitude/controllers/TreatmentPlanController.java
+++ b/src/main/java/com/habitude/controllers/TreatmentPlanController.java
@@ -1,0 +1,78 @@
+package com.habitude.controllers;
+
+import com.habitude.model.*;
+import com.habitude.repository.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+public class TreatmentPlanController {
+
+    private final TreatmentPlanRepository planRepo;
+    private final SubjectRepository subjectRepo;
+    private final GoalRepository goalRepo;
+    private final ObservationRepository obsRepo;
+
+    public TreatmentPlanController(TreatmentPlanRepository planRepo,
+                                   SubjectRepository subjectRepo,
+                                   GoalRepository goalRepo,
+                                   ObservationRepository obsRepo) {
+        this.planRepo    = planRepo;
+        this.subjectRepo = subjectRepo;
+        this.goalRepo    = goalRepo;
+        this.obsRepo     = obsRepo;
+    }
+
+    @PostMapping("/subjects/{subjectId}/treatment-plans")
+    @ResponseStatus(HttpStatus.CREATED)
+    public TreatmentPlan create(@PathVariable Long subjectId,
+                                @RequestBody TreatmentPlan input) {
+        Subject subject = subjectRepo.findById(subjectId)
+                .orElseThrow(() -> new RuntimeException("Subject not found"));
+        input.setSubject(subject);
+
+        if (input.getGoal() != null) {
+            Goal goal = goalRepo.findById(input.getGoal().getId())
+                    .orElseThrow(() -> new RuntimeException("Goal not found"));
+            input.setGoal(goal);
+        }
+        if (input.getObservation() != null) {
+            Observation obs = obsRepo.findById(input.getObservation().getId())
+                    .orElseThrow(() -> new RuntimeException("Observation not found"));
+            input.setObservation(obs);
+        }
+
+        return planRepo.save(input);
+    }
+
+    @GetMapping("/subjects/{subjectId}/treatment-plans")
+    public List<TreatmentPlan> listBySubject(@PathVariable Long subjectId) {
+        return planRepo.findBySubjectId(subjectId);
+    }
+
+    @GetMapping("/treatment-plans/{id}")
+    public TreatmentPlan getOne(@PathVariable Long id) {
+        return planRepo.findById(id)
+                .orElseThrow(() -> new RuntimeException("Plan not found"));
+    }
+
+    @PutMapping("/treatment-plans/{id}")
+    public TreatmentPlan update(@PathVariable Long id,
+                                @RequestBody TreatmentPlan updated) {
+        TreatmentPlan existing = planRepo.findById(id)
+                .orElseThrow(() -> new RuntimeException("Plan not found"));
+        existing.setPlan(updated.getPlan());
+        existing.setNextReview(updated.getNextReview());
+        existing.setNotes(updated.getNotes());
+        return planRepo.save(existing);
+    }
+
+    @DeleteMapping("/treatment-plans/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
+        planRepo.deleteById(id);
+    }
+}

--- a/src/main/java/com/habitude/controllers/UserController.java
+++ b/src/main/java/com/habitude/controllers/UserController.java
@@ -2,25 +2,45 @@ package com.habitude.controllers;
 
 import com.habitude.model.User;
 import com.habitude.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/users")
 public class UserController {
+    private final UserRepository repo;
 
-    @Autowired
-    private UserRepository userRepo;
+    public UserController(UserRepository repo) {
+        this.repo = repo;
+    }
 
     @GetMapping
-    public List<User> getAllUsers() {
-        return userRepo.findAll();
+    public List<User> all() {
+        return repo.findAll();
     }
 
     @PostMapping
-    public User createUser(@RequestBody User newUser) {
-        return userRepo.save(newUser);
+    public User create(@RequestBody User u) {
+        return repo.save(u);
+    }
+
+    @GetMapping("/{id}")
+    public User get(@PathVariable Long id) {
+        return repo.findById(id).orElseThrow();
+    }
+
+    @PutMapping("/{id}")
+    public User update(@PathVariable Long id, @RequestBody User u) {
+        User existing = repo.findById(id).orElseThrow();
+        existing.setEmail(u.getEmail());
+        existing.setName(u.getName());
+        existing.setRole(u.getRole());
+        return repo.save(existing);
+    }
+
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable Long id) {
+        repo.deleteById(id);
     }
 }
+

--- a/src/main/java/com/habitude/model/Goal.java
+++ b/src/main/java/com/habitude/model/Goal.java
@@ -1,0 +1,50 @@
+package com.habitude.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "goals")
+public class Goal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // which child this goal belongs to
+    @ManyToOne
+    @JoinColumn(name = "subject_id", nullable = false)
+    private Subject subject;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String description;
+
+    private LocalDate targetDate;
+
+    // e.g., "not started", "in progress", "achieved"
+    private String status;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    // getters & setters
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public Subject getSubject() { return subject; }
+    public void setSubject(Subject subject) { this.subject = subject; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public LocalDate getTargetDate() { return targetDate; }
+    public void setTargetDate(LocalDate targetDate) { this.targetDate = targetDate; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+}

--- a/src/main/java/com/habitude/model/Goals.java
+++ b/src/main/java/com/habitude/model/Goals.java
@@ -1,4 +1,0 @@
-package com.habitude.model;
-
-public class Goals {
-}

--- a/src/main/java/com/habitude/model/LLMFeedback.java
+++ b/src/main/java/com/habitude/model/LLMFeedback.java
@@ -1,0 +1,79 @@
+package com.habitude.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "llm_feedback")
+public class LLMFeedback {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** which observation this feedback is for */
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "observation_id")
+    private Observation observation;
+
+    /** the AI-generated suggestion */
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String suggestion;
+
+    /** whether the user accepted it */
+    private Boolean accepted;
+
+    /** model’s confidence (0.0–1.0) */
+    private Float confidenceScore;
+
+    /** when it was generated */
+    @Column(name = "generated_at")
+    private LocalDateTime generatedAt = LocalDateTime.now();
+
+    public LLMFeedback() {}
+
+    // — getters & setters —
+
+    public Long getId() {
+        return id;
+    }
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Observation getObservation() {
+        return observation;
+    }
+    public void setObservation(Observation observation) {
+        this.observation = observation;
+    }
+
+    public String getSuggestion() {
+        return suggestion;
+    }
+    public void setSuggestion(String suggestion) {
+        this.suggestion = suggestion;
+    }
+
+    public Boolean getAccepted() {
+        return accepted;
+    }
+    public void setAccepted(Boolean accepted) {
+        this.accepted = accepted;
+    }
+
+    public Float getConfidenceScore() {
+        return confidenceScore;
+    }
+    public void setConfidenceScore(Float confidenceScore) {
+        this.confidenceScore = confidenceScore;
+    }
+
+    public LocalDateTime getGeneratedAt() {
+        return generatedAt;
+    }
+    public void setGeneratedAt(LocalDateTime generatedAt) {
+        this.generatedAt = generatedAt;
+    }
+}
+

--- a/src/main/java/com/habitude/model/Observation.java
+++ b/src/main/java/com/habitude/model/Observation.java
@@ -1,58 +1,103 @@
 package com.habitude.model;
+
+import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
+@Entity
+@Table(name = "observations")
 public class Observation {
-    private String type;
-    private String description;
-    private double duration;
-    private double frequency;
-    private LocalDateTime timeStamp;
 
-    public Observation(String type, String description, double duration, double frequency) {
-        this.type = type;
-        this.description = description;
-        this.duration = duration;
-        this.frequency = frequency;
-        this.timeStamp = LocalDateTime.now();
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** which subject this log belongs to */
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "subject_id")
+    private Subject subject;
+
+    /** who logged it */
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "observer_id")
+    private User observer;
+
+    /** the behavior description */
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String behavior;
+
+    private String context;
+
+    @Column(nullable = false)
+    private LocalDateTime timestamp = LocalDateTime.now();
+
+    private Integer duration;  // in seconds
+    private Integer frequency; // count
+    private String intensity;  // low/medium/high
+
+    public Observation() {}
+
+    // getters & setters
+
+    public Long getId() {
+        return id;
+    }
+    public void setId(Long id) {
+        this.id = id;
     }
 
-    public String getType() {
-        return type;
+    public Subject getSubject() {
+        return subject;
+    }
+    public void setSubject(Subject subject) {
+        this.subject = subject;
     }
 
-    public void setType(String type) {
-        this.type = type;
+    public User getObserver() {
+        return observer;
+    }
+    public void setObserver(User observer) {
+        this.observer = observer;
     }
 
-    public String getDescription() {
-        return description;
+    public String getBehavior() {
+        return behavior;
+    }
+    public void setBehavior(String behavior) {
+        this.behavior = behavior;
     }
 
-    public void setDescription(String description) {
-        this.description = description;
+    public String getContext() {
+        return context;
+    }
+    public void setContext(String context) {
+        this.context = context;
     }
 
-    public double getDuration() {
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+    public void setTimestamp(LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public Integer getDuration() {
         return duration;
     }
-
-    public void setDuration(double duration) {
+    public void setDuration(Integer duration) {
         this.duration = duration;
     }
 
-    public LocalDateTime getTimeStamp() {
-        return timeStamp;
-    }
-
-    public void setTimeStamp(LocalDateTime timeStamp) {
-        this.timeStamp = timeStamp;
-    }
-
-    public double getFrequency() {
+    public Integer getFrequency() {
         return frequency;
     }
-
-    public void setFrequency(double frequency) {
+    public void setFrequency(Integer frequency) {
         this.frequency = frequency;
+    }
+
+    public String getIntensity() {
+        return intensity;
+    }
+    public void setIntensity(String intensity) {
+        this.intensity = intensity;
     }
 }

--- a/src/main/java/com/habitude/model/Subject.java
+++ b/src/main/java/com/habitude/model/Subject.java
@@ -1,0 +1,91 @@
+package com.habitude.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import com.habitude.model.User;   // ← make sure you import your User entity
+
+@Entity
+@Table(name = "subjects")
+public class Subject {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** The parent/therapist who “owns” this subject */
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    /** Child’s name */
+    @Column(nullable = false)
+    private String name;
+
+    /** Date of birth */
+    @Column(nullable = false)
+    private LocalDateTime dob;
+
+    /** Any free-text notes */
+    @Column(columnDefinition = "TEXT")
+    private String notes;
+
+    /** When this subject record was created */
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    // JPA requires a no-arg constructor
+    public Subject() {}
+
+    // (Optional) convenience constructor
+    public Subject(User user, String name, LocalDateTime dob, String notes) {
+        this.user      = user;
+        this.name      = name;
+        this.dob       = dob;
+        this.notes     = notes;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    // ——————— getters & setters ———————
+
+    public Long getId() {
+        return id;
+    }
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public LocalDateTime getDob() {
+        return dob;
+    }
+    public void setDob(LocalDateTime dob) {
+        this.dob = dob;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/habitude/model/TreatmentPlan.java
+++ b/src/main/java/com/habitude/model/TreatmentPlan.java
@@ -1,0 +1,121 @@
+package com.habitude.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "treatment_plans")
+public class TreatmentPlan {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Which child this plan is for */
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "subject_id", nullable = false)
+    private Subject subject;
+
+    /** Which goal this plan supports */
+    @ManyToOne
+    @JoinColumn(name = "goal_id")
+    private Goal goal;
+
+    /** link back to a specific observation */
+    @ManyToOne
+    @JoinColumn(name = "observation_id")
+    private Observation observation;
+
+    /** The actual intervention steps */
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String plan;
+
+    /** When this plan was created */
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    /** When to revisit/update this plan */
+    @Column(name = "next_review")
+    private LocalDateTime nextReview;
+
+    /** Any extra notes */
+    @Column(columnDefinition = "TEXT")
+    private String notes;
+
+    // JPA requires a no-arg constructor
+    public TreatmentPlan() {}
+
+    // Convenience constructor
+    public TreatmentPlan(Subject subject,
+                         Goal goal,
+                         Observation observation,
+                         String plan,
+                         LocalDateTime nextReview,
+                         String notes) {
+        this.subject     = subject;
+        this.goal        = goal;
+        this.observation = observation;
+        this.plan        = plan;
+        this.nextReview  = nextReview;
+        this.notes       = notes;
+        this.createdAt   = LocalDateTime.now();
+    }
+
+    // ————— getters & setters —————
+
+    public Long getId() {
+        return id;
+    }
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Subject getSubject() {
+        return subject;
+    }
+    public void setSubject(Subject subject) {
+        this.subject = subject;
+    }
+
+    public Goal getGoal() {
+        return goal;
+    }
+    public void setGoal(Goal goal) {
+        this.goal = goal;
+    }
+
+    public Observation getObservation() {
+        return observation;
+    }
+    public void setObservation(Observation observation) {
+        this.observation = observation;
+    }
+
+    public String getPlan() {
+        return plan;
+    }
+    public void setPlan(String plan) {
+        this.plan = plan;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getNextReview() {
+        return nextReview;
+    }
+    public void setNextReview(LocalDateTime nextReview) {
+        this.nextReview = nextReview;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+}

--- a/src/main/java/com/habitude/repository/GoalRepository.java
+++ b/src/main/java/com/habitude/repository/GoalRepository.java
@@ -1,0 +1,9 @@
+package com.habitude.repository;
+
+import com.habitude.model.Goal;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface GoalRepository extends JpaRepository<Goal, Long> {
+    List<Goal> findBySubjectId(Long subjectId);
+}

--- a/src/main/java/com/habitude/repository/LLMFeedbackRepository.java
+++ b/src/main/java/com/habitude/repository/LLMFeedbackRepository.java
@@ -1,0 +1,10 @@
+package com.habitude.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.habitude.model.LLMFeedback;
+import java.util.List;
+
+public interface LLMFeedbackRepository extends JpaRepository<LLMFeedback, Long> {
+    List<LLMFeedback> findByObservationId(Long observationId);
+}
+

--- a/src/main/java/com/habitude/repository/ObservationRepository.java
+++ b/src/main/java/com/habitude/repository/ObservationRepository.java
@@ -1,0 +1,10 @@
+package com.habitude.repository;
+
+import com.habitude.model.Observation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface ObservationRepository extends JpaRepository<Observation, Long> {
+    List<Observation> findBySubjectId(Long subjectId);
+}
+

--- a/src/main/java/com/habitude/repository/SubjectRepository.java
+++ b/src/main/java/com/habitude/repository/SubjectRepository.java
@@ -1,0 +1,10 @@
+package com.habitude.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.habitude.model.Subject;
+import java.util.List;
+
+public interface SubjectRepository extends JpaRepository<Subject, Long> {
+    // find all subjects for a given user
+    List<Subject> findByUserId(Long userId);
+}

--- a/src/main/java/com/habitude/repository/TreatmentPlanRepository.java
+++ b/src/main/java/com/habitude/repository/TreatmentPlanRepository.java
@@ -1,0 +1,9 @@
+package com.habitude.repository;
+
+import com.habitude.model.TreatmentPlan;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface TreatmentPlanRepository extends JpaRepository<TreatmentPlan, Long> {
+    List<TreatmentPlan> findBySubjectId(Long subjectId);
+}

--- a/src/main/java/com/habitude/repository/UserRepository.java
+++ b/src/main/java/com/habitude/repository/UserRepository.java
@@ -4,5 +4,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.habitude.model.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    // Optional: custom query methods go here
 }

--- a/src/main/java/com/habitude/service/ObservationService.java
+++ b/src/main/java/com/habitude/service/ObservationService.java
@@ -1,6 +1,9 @@
 package com.habitude.service;
+
 import com.habitude.model.Observation;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 import java.util.*;
 
 @Service
@@ -15,9 +18,26 @@ public class ObservationService {
     }
 
     public List<Observation> getAllObservations() {
-        List<Observation> mockObservation = new ArrayList<>();
-        mockObservation.add(new Observation("Behavior A", "First behavior", 20.0, 3.0));
-        mockObservation.add(new Observation("Behavior B", "Second hebavior", 15, 2.5));
-        return mockObservation;
+        List<Observation> mockObservations = new ArrayList<>();
+
+        // first fake record
+        Observation o1 = new Observation();             // no-arg constructor
+        o1.setBehavior("Behavior A");                  // we assume your entity has these setters
+        o1.setContext("First behavior");
+        o1.setDuration(20);
+        o1.setFrequency(3);
+        o1.setTimestamp(LocalDateTime.now());
+        mockObservations.add(o1);
+
+        // second fake record
+        Observation o2 = new Observation();
+        o2.setBehavior("Behavior B");
+        o2.setContext("Second behavior");
+        o2.setDuration(15);
+        o2.setFrequency(2);
+        o2.setTimestamp(LocalDateTime.now());
+        mockObservations.add(o2);
+
+        return mockObservations;
     }
 }


### PR DESCRIPTION
## Description
Implemented complete Create–Read–Update–Delete (CRUD) support for all of our database entities using Spring Data JPA and Spring MVC. This will give us a stable, testable REST API layer before we move on to the next features.

> ### Entities implemented:
> 1. User  
> 2. Subject  
> 3. Observation  
> 4. TreatmentPlan  
> 5. LLMFeedback  
>  
> ### Each entity follows the same three-layer pattern:
> - **Entity** (@Entity in `com.habitude.model`)  
> - **Repository** (interface extends `JpaRepository` in `com.habitude.repository`)  
> - **Controller** (@RestController in `com.habitude.controllers`)  
>  
> ### Each controller should expose these endpoints for its entity:
> ```
> GET    /api/xxx
> POST   /api/xxx
> GET    /api/xxx/{id}
> PUT    /api/xxx/{id}
> DELETE /api/xxx/{id}
> ```
>  
> ### Build & run locally:
> ```bash
> mvn clean package
> java -jar target/habitude-backend-1.0.0.jar
> ```
>  
> ### Some sample Tests in Postman or with curl:
> ```bash
> #–– User CRUD ––
> curl http://localhost:8080/api/users
> curl -X POST http://localhost:8080/api/users \
>   -H "Content-Type: application/json" \
>   -d '{"email":"a@b.com","name":"Alice","role":"parent"}'
> 
> #–– Observation Service (mock) ––
> curl http://localhost:8080/api/observations/summary
> curl http://localhost:8080/api/observations
> 
> #–– Subject CRUD ––
> # 1) Create a subject for user 1
> curl -i -X POST http://localhost:8080/api/users/1/subjects \
>   -H "Content-Type: application/json" \
>   -d '{"name":"Sammy","dob":"2018-05-20T00:00:00","notes":"Loves drawing"}'
> 
> # 2) List subjects for user 1
> curl http://localhost:8080/api/users/1/subjects
> 
> # 3) Get a single subject
> curl http://localhost:8080/api/subjects/1
> 
> # 4) Update a subject
> curl -i -X PUT http://localhost:8080/api/subjects/1 \
>   -H "Content-Type: application/json" \
>   -d '{"name":"Samuel","dob":"2018-05-20T00:00:00","notes":"Now loves puzzles"}'
> 
> # 5) Delete a subject
> curl -i -X DELETE http://localhost:8080/api/subjects/1
> ```
>  
> ### Verify via psql that your tables and rows exist.

---

## Additionally:  
This PR fixes a compilation error in `ObservationService` (and aligns it with our JPA entity design):

- **ObservationService**  
  - Switched from calling a now-removed multi-arg `new Observation(...)` constructor to using the no-arg constructor + setter methods.  
  - Populates two mock observations in `getAllObservations()` so that `/api/observations` returns a valid list again.

- **Observation entity**  
  - Kept only the JPA-required no-arg constructor.  
  - Ensured we have setters for all fields used in the service (`setBehavior`, `setContext`, `setDuration`, `setFrequency`, `setTimestamp`).

### Why  
- JPA entities must have a public or protected no-arg constructor.  
- Our service layer was still creating observations via a custom constructor that no longer exists.  
- This change restores a working mock endpoint and keeps our entity strictly JPA-compliant.

### How to test  
1. Build & run locally:  
   ```bash
   mvn clean package
   java -jar target/habitude-backend-1.0.0.jar
