### PR TITLE
- Added JPA entity `Observation` with links to `Subject` and `User`

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="corretto-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Android API 35, extension level 13 Platform" project-jdk-type="Android SDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/java/com/habitude/controllers/ObservationController.java
+++ b/src/main/java/com/habitude/controllers/ObservationController.java
@@ -4,20 +4,33 @@ import com.habitude.service.ObservationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
 import java.util.*;
 
 @RestController
+@RequestMapping("/api/observations")
 public class ObservationController {
+
     @Autowired
     private ObservationService observationService;
 
-    @GetMapping("/api/observations/summary")
+    @GetMapping("/summary")
     public Map<String, Object> getSummary() {
         return observationService.getSummary();
     }
 
-    @GetMapping("/api/observations")
+    @GetMapping
     public List<Observation> getAllObservations() {
         return observationService.getAllObservations();
+    }
+
+    @GetMapping("/trend")
+    public Map<String, Object> getTrendData() {
+        return observationService.getTrendData();
+    }
+
+    @GetMapping("/trend/by-subject/{subjectId}")
+    public Map<String, Object> getTrendDataBySubject(@PathVariable Long subjectId) {
+        return observationService.getTrendDataBySubject(subjectId);
     }
 }

--- a/src/main/java/com/habitude/model/Observation.java
+++ b/src/main/java/com/habitude/model/Observation.java
@@ -32,9 +32,20 @@ public class Observation {
 
     private Integer duration;  // in seconds
     private Integer frequency; // count
-    private String intensity;  // low/medium/high
+    private Intensity intensity;  // low/medium/high
 
     public Observation() {}
+
+    public enum Intensity {
+        LOW, MEDIUM, HIGH
+    }
+
+    @PrePersist
+    public void prePersist() {
+        if (this.timestamp == NULL) {
+            this.timestamp = LocalDateTime.now();
+        }
+    }
 
     // getters & setters
 

--- a/src/main/java/com/habitude/service/ObservationService.java
+++ b/src/main/java/com/habitude/service/ObservationService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 public class ObservationService {
@@ -62,7 +63,7 @@ public class ObservationService {
         List<Observation> observations = observationRepository.findAll();
 
         if (observations.isEmpty()) {
-            return Map.of("frequenctData", Collections.emptyList(), "durationData", Collections.emptyList());
+            return Map.of("frequencyData", Collections.emptyList(), "durationData", Collections.emptyList());
         }
         Map<LocalDateTime, List<Observation>> grouped = observations.stream()
                 .collect(Collectors.groupingBy(o -> o.getTimestamp().toLocalDate()));


### PR DESCRIPTION
- Implemented `ObservationRepository` with custom query for subject-specific data
- Fixed `ObservationService` for:
  - mock data fallback
  - summary logic
  - trend data grouped by date
- Fixed `ObservationController` endpoints:
  - /api/observations
  - /api/observations/summary
  - /api/observations/trends
  - /api/observations/trends/by-subject/{subjectId}