### PR TITLE
Bypass Login in Dev Environment

### DIFF
--- a/src/main/java/com/habitude/config/DevSecurityConfig.java
+++ b/src/main/java/com/habitude/config/DevSecurityConfig.java
@@ -1,0 +1,27 @@
+package com.habitude.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@Profile("dev")
+@EnableWebSecurity
+public class DevSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                )
+                .formLogin().disable()
+                .httpBasic().disable();
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/habitude/config/SecurityConfig.java
+++ b/src/main/java/com/habitude/config/SecurityConfig.java
@@ -2,12 +2,14 @@ package com.habitude.config;
 import static org.springframework.security.config.Customizer.withDefaults;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
+@Profile("prod")
 public class SecurityConfig {
 
     @Bean

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,3 +15,4 @@ spring.security.oauth2.client.registration.github.client-secret=${GITHUB_CLIENT_
 spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
 spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}
 
+spring.profiles.active=dev


### PR DESCRIPTION
This PR introduces a new DevSecurityConfig class that disables login requirements when the dev profile is active. This allows for faster local development and testing by permitting unrestricted access to all endpoints.

Changes:
Added DevSecurityConfig with @Profile("dev")

Updated SecurityConfig with @Profile("prod") to avoid bean conflicts

Set spring.profiles.active=dev in application.properties (for local use)

When running with dev profile, login is bypassed. Production security remains unchanged.