### PR TITLE
Add Profile-Based Security Configurations (Dev vs Prod)

### DIFF
--- a/src/main/java/com/habitude/config/DevSecurityConfig.java
+++ b/src/main/java/com/habitude/config/DevSecurityConfig.java
@@ -24,4 +24,6 @@ public class DevSecurityConfig {
 
         return http.build();
     }
+
+
 }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,1 @@
+# No login ? handled by DevSecurityConfig

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,7 @@
+
+# Enable OAuth login
+spring.security.oauth2.client.registration.github.client-id=${GITHUB_CLIENT_ID}
+spring.security.oauth2.client.registration.github.client-secret=${GITHUB_CLIENT_SECRET}
+
+spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
+spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,18 +1,14 @@
+# Database config (same for all profiles)
 spring.datasource.url=jdbc:postgresql://ec2-18-218-252-78.us-east-2.compute.amazonaws.com:5432/habitude_db
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
+
+# Hibernate
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
+# Logging
 logging.level.org.springframework.security=TRACE
 
 
-
-spring.security.oauth2.client.registration.github.client-id=${GITHUB_CLIENT_ID}
-spring.security.oauth2.client.registration.github.client-secret=${GITHUB_CLIENT_SECRET}
-
-spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
-spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}
-
-spring.profiles.active=dev


### PR DESCRIPTION
##  Add Profile-Based Security Configurations (Dev vs. Prod)

### Description

This PR introduces profile-based Spring Security configurations to support separate authentication flows for development and production environments.

---

### Changes

-   **`DevSecurityConfig.java`**  
  - Activated under `dev` profile  
  - Disables all authentication and allows unrestricted access for local development

-  **`SecurityConfig.java`**  
  - Activated under `prod` profile  
  - Enables OAuth2 login and Spring Security's default login page for secure access in production

- **Configuration Files Split**  
  - `application.properties`: Shared values (DB, Hibernate, logging)  
  - `application-dev.properties`: Dev profile settings (no login)  
  - `application-prod.properties`: OAuth credentials and production-specific overrides

- Removed `spring.profiles.active` from profile-specific files to comply with Spring Boot 3.x constraints

---

### How to Use

- **Dev Mode (no login)**  
  ```bash
  java -jar target/habitude-backend-1.0.0.jar --spring.profiles.active=dev


- **Prod Mode (w/ login)**  

```bash
 java -jar target/habitude-backend-1.0.0.jar --spring.profiles.active=prod