### PR TITLE
feat: return 404 on missing observations and document test profile

### DIFF
--- a/src/main/java/com/habitude/controllers/ObservationController.java
+++ b/src/main/java/com/habitude/controllers/ObservationController.java
@@ -56,9 +56,9 @@ public class ObservationController {
 
     // create
     @PostMapping
-    public ResponseEntity<Observation> createObservation(@RequestBody Observation observation) {
-        Observation saved = observationService.saveObservation(observation);
-        return new ResponseEntity<>(saved, HttpStatus.CREATED);
+    @ResponseStatus(HttpStatus.CREATED)
+    public Observation createObservation(@RequestBody Observation observation) {
+        return observationService.saveObservation(observation);
     }
 
     // update
@@ -71,8 +71,8 @@ public class ObservationController {
 
     // delete
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteObservation(@PathVariable Long id) {
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteObservation(@PathVariable Long id) {
         observationService.deleteObservation(id);
-        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/habitude/exception/ObservationNotFoundException.java
+++ b/src/main/java/com/habitude/exception/ObservationNotFoundException.java
@@ -1,0 +1,11 @@
+package com.habitude.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ObservationNotFoundException extends RuntimeException {
+    public ObservationNotFoundException(Long id) {
+        super("Observation not found with id " + id);
+    }
+}

--- a/src/test/java/com/habitude/controllers/ObservationControllerTest.java
+++ b/src/test/java/com/habitude/controllers/ObservationControllerTest.java
@@ -68,7 +68,7 @@ public class ObservationControllerTest {
         mockMvc.perform(post("/api/observations")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(obs)))
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").exists())
                 .andExpect(jsonPath("$.behavior", is("TestBehavior")));
     }
@@ -114,5 +114,23 @@ public class ObservationControllerTest {
         mockMvc.perform(get("/api/observations/mock"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(greaterThan(0))));
+    }
+
+    @Test
+    void testDeleteObservation() throws Exception {
+        Observation obs = new Observation();
+        obs.setSubject(testSubject);
+        obs.setObserver(testUser);
+        obs.setBehavior("ToBeDeleted");
+        obs.setTimestamp(LocalDateTime.now());
+        obs = obsRepo.save(obs);
+
+        // delete
+        mockMvc.perform(delete("/api/observations/{id}", obs.getId()))
+                .andExpect(status().isNoContent());
+
+        // GET afterwards currently returns 5xx
+        mockMvc.perform(get("/api/observations/{id}", obs.getId()))
+                .andExpect(status().isNotFound());
     }
 }


### PR DESCRIPTION
### Description:

> Added ObservationNotFoundException annotated with @ResponseStatus(HttpStatus.NOT_FOUND).
> Cleaned up ObservationService and ObservationController to use that exception.
> Updated ObservationControllerTest to expect 404 on GET after delete.
> Run tests with:  

> ```
>  mvn clean test -Dspring.profiles.active=test
> ```